### PR TITLE
fix(ci): publish release images under every sha the installed ref resolves to

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,10 +24,27 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      - name: Update container in operator JSON
+        with:
+          fetch-depth: 0
+      # Tercen resolves the tag-less `container` in operator.json by appending the SHA it
+      # parses out of the GitHub zipball directory name (`<org>-<repo>-<short-sha>/`), so
+      # the image must carry that exact tag. That name uses the sha of the *ref object*,
+      # which for an ANNOTATED tag is the tag object, not the commit — e.g. 1.1.0 resolves
+      # to 4be5a84, while the commit is 65938db. Peeling with HEAD^{commit} is therefore
+      # not sufficient on its own, so publish both shas (short and full). Lightweight tags
+      # remain the preferred convention, where the two are identical.
+      #
+      # The old "patch operator.json in the runner" step was dead code: Tercen reads
+      # operator.json from the git checkout at the installed ref, never from the built
+      # image or the runner workspace.
+      - name: Resolve commit SHA
+        id: commit
         run: |
-          jq --arg variable "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${GITHUB_REF##*/}" '.container = $variable' operator.json > operator.json.tmp
-          mv operator.json.tmp operator.json
+          set -euo pipefail
+          echo "sha=$(git rev-parse "${GITHUB_REF}^{commit}")" >> "$GITHUB_OUTPUT"
+          echo "sha_short=$(git rev-parse --short=7 "${GITHUB_REF}^{commit}")" >> "$GITHUB_OUTPUT"
+          echo "ref_sha=$(git rev-parse "${GITHUB_REF}")" >> "$GITHUB_OUTPUT"
+          echo "ref_sha_short=$(git rev-parse --short=7 "${GITHUB_REF}")" >> "$GITHUB_OUTPUT"
       # Uses the `docker/login-action` action to log in to the Container registry registry using the account and password that will publish the packages. Once published, the packages are scoped to the account defined here.
       - name: Log in to the Container registry
         uses: docker/login-action@v3.3.0
@@ -41,9 +58,15 @@ jobs:
         uses: docker/metadata-action@v5.5.1
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # Semver tag for humans, plus every sha the installed ref can resolve to
+          # (immutable) for Tercen's tag-less container resolution. When the tag is
+          # lightweight, ref_sha == sha and the duplicates collapse.
           tags: |
-            # minimal
             type=pep440,pattern={{version}}
+            type=raw,value=${{ steps.commit.outputs.sha }}
+            type=raw,value=${{ steps.commit.outputs.sha_short }}
+            type=raw,value=${{ steps.commit.outputs.ref_sha }}
+            type=raw,value=${{ steps.commit.outputs.ref_sha_short }}
       # This step uses the `docker/build-push-action` action to build the image, based on your repository's `Dockerfile`. If the build succeeds, it pushes the image to GitHub Packages.
       # It uses the `context` parameter to define the build's context as the set of files located in the specified path. For more information, see "[Usage](https://github.com/docker/build-push-action#usage)" in the README of the `docker/build-push-action` repository.
       # It uses the `tags` and `labels` parameters to tag and label the image with the output from the "meta" step.


### PR DESCRIPTION
Reported by PamGene (bionavigator) — running the Export Table data step failed with:

```
Error: unable to copy from source docker://ghcr.io/tercen/export_table_operator:4be5a84:
reading manifest 4be5a84 in ghcr.io/tercen/export_table_operator: manifest unknown
```

## Cause

Two defects compounding. Related: tercen/sci#1162.

**1. This repo is half-converted to the tag-less container pattern.** `operator.json` declares `"container": "ghcr.io/tercen/export_table_operator"` with no tag, which requires the image to carry a sha tag. `ci.yml` was updated to push short+full sha in `a45c107`; **`release.yml` was not** — it published only `type=pep440` (the semver tag). So no release image has ever carried a sha tag, and *every* release install of this operator resolves to a manifest that was never built. `1.1.0` is simply the one PamGene installed.

**2. The sha is not the commit sha for annotated tags.** Tercen parses it out of the GitHub zipball directory name (`git_operator.dart`, `<org>-<repo>-<short-sha>/`), and that name uses the sha of the **ref object**. For an annotated tag that is the tag object, not the commit:

```
refs/tags/1.0.8 -> commit 7e112d0689   <- lightweight, ref sha == commit
refs/tags/1.0.9 -> tag    8dff40a1b4   <- annotated
refs/tags/1.1.0 -> tag    4be5a8437a   <- annotated; commit is 65938dba6e
```

Confirmed directly against the API zipball endpoint this repo is installed through:

| ref | zipball root dir | parsed sha |
|---|---|---|
| `refs/tags/1.1.0` | `tercen-export_table_operator-4be5a84` | `4be5a84` (tag object) |
| `refs/tags/1.0.9` | `tercen-export_table_operator-8dff40a` | `8dff40a` (tag object) |
| `refs/tags/1.0.8` | `tercen-export_table_operator-7e112d0` | `7e112d0` (commit) |

That reproduces `4be5a84` exactly. Note this means the `rev-parse HEAD^{commit}` approach in the read_csv_operator template is **not** annotated-tag safe as its comment claims — peeling gives `65938db`, but Tercen asks for `4be5a84`.

## Change

`release.yml` now publishes the semver tag plus the peeled commit sha **and** the ref object sha, short and full. Lightweight tags collapse to a single sha, so this is a no-op for the preferred convention and a fix for annotated ones.

Dry-run against the existing tags:

```
refs/tags/1.1.0 (annotated)   -> 1.1.0, 65938dba6e..., 65938db, 4be5a8437a..., 4be5a84
refs/tags/1.0.8 (lightweight) -> 1.0.8, 7e112d0689..., 7e112d0
```

Also drops the `jq` "Update container in operator JSON" step — dead code per tercen/sci#1162, since Tercen reads `operator.json` from the git checkout, not the runner workspace.

## Already done out-of-band

The published `1.1.0` and `1.0.9` images have been given their missing sha aliases by hand (`4be5a84`, `8dff40a`, plus full shas — same manifest digests, purely additive), so PamGene's existing data step and any other affected install work now without a reinstall. This PR stops it recurring.

## Not done here

The published `1.0.9` / `1.1.0` git tags are left as annotated. Re-cutting them as lightweight would re-trigger this workflow and republish the `1.1.0` image, and the Dockerfile installs its R packages unpinned (`installr -d dplyr`, ...), so the rebuild would not be byte-identical to the artifact currently in production. Suggest adopting lightweight tags from the next release instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeoFKnewHFjCdPK45kWjDG
