### PR TITLE
fix: keep empty crosstab rows and columns through the reshape

### DIFF
--- a/main.R
+++ b/main.R
@@ -50,11 +50,21 @@ if(is.null(wfId)) { # unit test condition
   }
 }
 
-df_wide <- dcast(df_long, .ri ~ .ci, value.var = ".y")
-raw_data <- df_wide[order(.ri)][, !".ri"]
-
 row_values <- as.data.table(ctx$rselect())
 col_values <- as.data.table(ctx$cselect())
+
+# dcast only emits a row/column per .ri/.ci value that actually occurs, so a crosstab
+# row or column holding no observations at all would silently drop out and leave the
+# data block smaller than the headers built from rselect()/cselect() - which then fails
+# in colnames<- ("Can't assign N names to an M-column data.table"). Pin the levels to
+# the full index range and keep the empty ones so the block always lines up.
+n_ri <- max(nrow(row_values), max(df_long$.ri) + 1L)
+n_ci <- max(nrow(col_values), max(df_long$.ci) + 1L)
+df_long[, .ri := factor(.ri, levels = seq_len(n_ri) - 1L)]
+df_long[, .ci := factor(.ci, levels = seq_len(n_ci) - 1L)]
+
+df_wide <- dcast(df_long, .ri ~ .ci, value.var = ".y", drop = FALSE)
+raw_data <- df_wide[order(.ri)][, !".ri"]
 yaxis_names <- unlist(ctx$yAxis)
 if (length(yaxis_names) == 0) yaxis_names <- ""
 row_names_in <- names(ctx$rnames)


### PR DESCRIPTION
Reported by PamGene (bionavigator) after upgrading to 1.1.1:

```
Failed to run operator, exit code = 1
Error in setnames(x, value) : Can't assign 5 names to a 4-column data.table
Calls: colnames<- ... names<-.data.table -> setnames -> stopf
```

## Cause

`dcast` only emits a row/column for each `.ri`/`.ci` value that actually occurs in the data. A crosstab row or column with **no observations at all** therefore drops out of the wide table, while the headers are still built from the full `rselect()` / `cselect()`. The two then disagree:

```r
df_wide  <- dcast(df_long, .ri ~ .ci, value.var = ".y")   # narrower than cselect()
raw_data <- df_wide[order(.ri)][, !".ri"]
...
colnames(df_out) <- c(row_block$names, new_col_names)     # boom
```

## The error is the *good* outcome

When the number of surviving rows divides evenly into the expected count, `cbind()` recycles instead of erroring and the export **silently contains the wrong values**, with only a warning:

```
4 crosstab rows, rows 2 and 4 empty:
      Row     0     1     2
1:     r1     1     2     3
2:     r2     4     5     6
3:     r3     1     2     3   <- should be empty; carries r1's data
4:     r4     4     5     6   <- should be empty; carries r2's data
```

The default crosstab-view path (`collapse_cols = FALSE`) is affected the same way. So an unknown number of previously "successful" exports from tables with empty rows/columns may contain misaligned data.

## Fix

Pin the `.ri`/`.ci` factor levels to the full index range and reshape with `drop = FALSE`, so the data block always lines up with the headers and genuinely empty cells come through as `NA`.

## Verification

Ran the real `main.R` against a mock context, comparing every cell value against the expected grid.

Before (as released in 1.1.1):

```
== collapse_cols = TRUE ==
  no holes (regression)    -> PASS
  one empty column         -> ERROR: Can't assign 5 names to a 4-column data.table
  one empty row            -> ERROR: SILENT RECYCLING
  empty row + column       -> ERROR: SILENT RECYCLING
  2 of 4 rows empty        -> FAIL values misaligned/recycled
== collapse_cols = FALSE ==
  no holes (regression)    -> PASS
  one empty column         -> FAIL shape 3x3 want 3x4
  one empty row            -> ERROR: SILENT RECYCLING
  empty row + column       -> ERROR: SILENT RECYCLING
  2 of 4 rows empty        -> FAIL values misaligned/recycled
```

After: all 10 PASS.

Regression checks:
- shipped `tests/test_1` fixture reproduces its expected output **byte-identical**
- CSV, TSV and XLSX all write valid output in both `collapse_cols` modes, and with `collapse_rows = TRUE`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EeoFKnewHFjCdPK45kWjDG
